### PR TITLE
IOS video blackscreen issue

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -77,6 +77,14 @@ export class WebRTCClient  {
             this.ResetVideo();
             setTimeout(() => { this.DoneHandshake(); },3000)
             LogConnectionEvent(ConnectionEvent.ReceivedVideoStream);
+            // we should put an alert here to comply webkit policy
+            if (this.platform == 'mobile') {
+                let text = "Press a button!\nEither OK or Cancel.";
+                if (confirm(text) == true) {
+                    text = "You pressed OK!";
+                }
+            }
+
             this.video.srcObject = evt.streams[0]
             setInterval(async () => {  // user must interact with the document first, by then, video can start to play. so we wait for use to interact
                 try {

--- a/src/app.ts
+++ b/src/app.ts
@@ -65,6 +65,7 @@ export class WebRTCClient  {
         if (evt.track.kind == "audio")
         {
             LogConnectionEvent(ConnectionEvent.ReceivedAudioStream);
+            this.audio.srcObject = null;
             this.audio.srcObject = evt.streams[0]
             setInterval(async () => {  // user must interact with the document first, by then, audio can start to play. so we wait for use to interact
                 try {
@@ -85,6 +86,8 @@ export class WebRTCClient  {
                 }
             }
 
+
+            this.video.srcObject = null;
             this.video.srcObject = evt.streams[0]
             setInterval(async () => {  // user must interact with the document first, by then, video can start to play. so we wait for use to interact
                 try {


### PR DESCRIPTION
this pull request is for solving video issue on IOS device:

Audio is working fine across all browser , only issue arise is when video.play() is called, the video turned black (instead of video stream)
This is definitively not connectivity issue, since audio is working fine, data channel is working fine
There is no exception throw from browser console log showing that video is unable to play
Video metadata is still be able to get properly from browser side (video width and height), touch events are also being able to send to server

https://cdn.discordapp.com/attachments/1085744313155195011/1103979727854772254/RPReplay_Final1683279633.mov