### PR TITLE
fix: datachannel not working when have multiple channels

### DIFF
--- a/core/datachannel/datachannel.ts
+++ b/core/datachannel/datachannel.ts
@@ -11,11 +11,12 @@ export class DataChannel {
         let sent = false;
         let retry = 0;
         while (!sent && retry <= 5) {
-            for (const [key, value] of Array.from(this.channel.entries())) {
+            const entries = Array.from(this.channel.entries()).sort((a, b) => b[0] - a[0]);
+            for (const [key, value] of entries) {
                 if (sent || value.readyState != 'open') continue;
-                sent = true;
                 try {
                     value.send(message);
+                    sent = true;
                 } catch {
                     sent = false;
                 }
@@ -27,7 +28,7 @@ export class DataChannel {
     }
 
     public SetSender(chan: RTCDataChannel) {
-        const id = Date.now();
+        const id = chan?.id || Date.now();
 
         const close = () => {
             this.channel.delete(id);


### PR DESCRIPTION
RTCDataChannel.send is not an async function, it push the message to the queue and handle in somwhere else. So the try/catch is not working when we have connection error

-> In the current code base we always stop at the first element of `this.channel`

This PR change:
- Revert the lookup order of channel map
- Change to use channel.id instead of timestamp ([for reference](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/id))